### PR TITLE
Fix parse bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.1.0
 
-- fix parse bug.
-- add lint package.
+- Properly handle optional titles and lengths according to PLS format.
+- Override `==` and `hashCode` for `PlsEntry` and `PlsPlaylist`.
+- Add linter.
 
 ## 1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0
+
+- fix parse bug.
+- add lint package.
+
 ## 1.0.4
 
 - Remove flutter dependencies.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,22 @@
-include: package:lints/recommended.yaml
+include: package:lint/package.yaml # Use this for packages with public API
+
+
+# You might want to exclude auto-generated files from dart analysis
+analyzer:
+  exclude:
+  #- '**.freezed.dart'
+  #- '**.g.dart'
+
+# You can customize the lint rules set to your own liking. A list of all rules
+# can be found at https://dart-lang.github.io/linter/lints/options/options.html
+linter:
+  rules:
+  # Util classes are awesome!
+  # avoid_classes_with_only_static_members: false
+
+  # Make constructors the first thing in every class
+  # sort_constructors_first: true
+
+  # Choose wisely, but you don't have to
+  # prefer_double_quotes: true
+  # prefer_single_quotes: true

--- a/lib/src/pls_entry.dart
+++ b/lib/src/pls_entry.dart
@@ -1,5 +1,7 @@
+import 'package:equatable/equatable.dart';
+
 /// Pls entry that specifies the media file.
-class PlsEntry {
+class PlsEntry extends Equatable {
   /// Location of media file/stream.
   final String? file;
 
@@ -12,5 +14,8 @@ class PlsEntry {
   final int? length;
 
   /// Creates [PlsEntry] that specifies the media file.
-  PlsEntry({this.file, this.title, this.length});
+  const PlsEntry({this.file, this.title, this.length});
+
+  @override
+  List<Object?> get props => [file, title, length];
 }

--- a/lib/src/pls_entry.dart
+++ b/lib/src/pls_entry.dart
@@ -1,7 +1,5 @@
-import 'package:equatable/equatable.dart';
-
 /// Pls entry that specifies the media file.
-class PlsEntry extends Equatable {
+class PlsEntry {
   /// Location of media file/stream.
   final String? file;
 
@@ -17,5 +15,15 @@ class PlsEntry extends Equatable {
   const PlsEntry({this.file, this.title, this.length});
 
   @override
-  List<Object?> get props => [file, title, length];
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is PlsEntry &&
+        other.file == file &&
+        other.title == title &&
+        other.length == length;
+  }
+
+  @override
+  int get hashCode => file.hashCode ^ title.hashCode ^ length.hashCode;
 }

--- a/lib/src/pls_playlist.dart
+++ b/lib/src/pls_playlist.dart
@@ -1,9 +1,8 @@
-library pls;
-
-import 'pls_entry.dart';
+import 'package:equatable/equatable.dart';
+import 'package:pls/src/pls_entry.dart';
 
 /// Pls playlist.
-class PlsPlaylist {
+class PlsPlaylist extends Equatable {
   /// The total number of entries in the playlist.
   final int? numberOfEntries;
 
@@ -18,61 +17,40 @@ class PlsPlaylist {
   /// Creates a [PlsPlaylist] with a list [PlsEntry],
   /// total number of records [numberOfEntries],
   /// and PLS [version].
-  PlsPlaylist({this.entries, this.numberOfEntries, this.version});
+  const PlsPlaylist({this.entries, this.numberOfEntries, this.version});
 
   /// Parses Pls playlist from a document string.
   factory PlsPlaylist.parse(String src) {
-    List<PlsEntry> entryList = [];
-    List<String?> fileList = [];
-    List<String?> listTitle = [];
-    List<int?> lengthsList = [];
-    int? entriesCount;
-    int? plsVersion;
+    final List<PlsEntry> entryList = [];
 
-    // Get url
-    final regexUrl = RegExp(r'[Ff]ile[0-9]+\=(.*)');
-    final matchUrl = regexUrl.allMatches(src);
-    for (RegExpMatch element in matchUrl) {
-      final url = element.group(1);
-      fileList.add(url);
-    }
+    final regexNumberOfEntries = RegExp('[Nn]umber[oO]f[eE]ntries=(.*)');
+    final matchEntries = regexNumberOfEntries.firstMatch(src);
+    final entriesString = matchEntries?.group(1);
+    final int entriesCount =
+        entriesString != null ? int.tryParse(entriesString) ?? 0 : 0;
 
-    // Get title
-    final regexTitle = RegExp(r'[Tt]itle[0-9]+\=(.*)');
-    final matchTitle = regexTitle.allMatches(src);
-    for (RegExpMatch element in matchTitle) {
-      final title = element.group(1);
-      listTitle.add(title);
-    }
-
-    // Get length
-    final regexLength = RegExp(r'[Ll]ength[0-9]+\=(.*)');
-    final matchLength = regexLength.allMatches(src);
-    for (RegExpMatch element in matchLength) {
-      final length = element.group(1);
-      lengthsList.add(length != null ? int.tryParse(length) : null);
-    }
-
-    // Get numberOfEntries
-    final regexNumberOfEntries = RegExp(r'[Nn]umber[oO]f[eE]ntries\=(.*)');
-    final match = regexNumberOfEntries.firstMatch(src);
-    final entriesString = match?.group(1);
-    entriesCount = entriesString != null ? int.tryParse(entriesString) : null;
-
-    // Get version
-    final regexVersion = RegExp(r'[Vv]ersion\=(.*)');
+    final regexVersion = RegExp('[Vv]ersion=(.*)');
     final matchVersion = regexVersion.firstMatch(src);
     final versionString = matchVersion?.group(1);
-    plsVersion = versionString != null ? int.tryParse(versionString) : null;
+    final int? plsVersion =
+        versionString != null ? int.tryParse(versionString) : null;
 
-    for (int i = 0; i < fileList.length; i++) {
-      entryList.add(
-        PlsEntry(
-          file: fileList[i],
-          title: listTitle[i],
-          length: lengthsList.isEmpty ? null : lengthsList[i],
-        ),
-      );
+    for (int i = 1; i <= entriesCount; i++) {
+      final fileRegex = RegExp('File$i=(.*)', caseSensitive: false);
+      final titleRegex = RegExp('Title$i=(.*)', caseSensitive: false);
+      final lengthRegex = RegExp('Length$i=(.*)', caseSensitive: false);
+
+      final fileMatch = fileRegex.firstMatch(src);
+      final titleMatch = titleRegex.firstMatch(src);
+      final lengthMatch = lengthRegex.firstMatch(src);
+
+      final file = fileMatch?.group(1);
+      final title = titleMatch?.group(1);
+      final length = lengthMatch?.group(1) != null
+          ? int.tryParse(lengthMatch!.group(1)!)
+          : null;
+
+      entryList.add(PlsEntry(file: file, title: title, length: length));
     }
 
     return PlsPlaylist(
@@ -81,4 +59,7 @@ class PlsPlaylist {
       numberOfEntries: entriesCount,
     );
   }
+
+  @override
+  List<Object?> get props => [entries, version, numberOfEntries];
 }

--- a/lib/src/pls_playlist.dart
+++ b/lib/src/pls_playlist.dart
@@ -12,12 +12,16 @@ class PlsPlaylist extends Equatable {
   final int? version;
 
   /// List of entries media files [PlsEntry].
-  final List<PlsEntry>? entries;
+  final List<PlsEntry> entries;
 
   /// Creates a [PlsPlaylist] with a list [PlsEntry],
   /// total number of records [numberOfEntries],
   /// and PLS [version].
-  const PlsPlaylist({this.entries, this.numberOfEntries, this.version});
+  const PlsPlaylist({
+    this.entries = const [],
+    this.numberOfEntries,
+    this.version,
+  });
 
   /// Parses Pls playlist from a document string.
   factory PlsPlaylist.parse(String src) {

--- a/lib/src/pls_playlist.dart
+++ b/lib/src/pls_playlist.dart
@@ -1,8 +1,7 @@
-import 'package:equatable/equatable.dart';
 import 'package:pls/src/pls_entry.dart';
 
 /// Pls playlist.
-class PlsPlaylist extends Equatable {
+class PlsPlaylist {
   /// The total number of entries in the playlist.
   final int? numberOfEntries;
 
@@ -65,5 +64,33 @@ class PlsPlaylist extends Equatable {
   }
 
   @override
-  List<Object?> get props => [entries, version, numberOfEntries];
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is PlsPlaylist &&
+        _listEquals(other.entries, entries) &&
+        other.numberOfEntries == numberOfEntries &&
+        other.version == version;
+  }
+
+  @override
+  int get hashCode =>
+      _listHashCode(entries) ^ numberOfEntries.hashCode ^ version.hashCode;
+
+  bool _listEquals(List<Object> a, List<Object> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+
+  int _listHashCode(List<Object> list) {
+    int result = 0;
+    for (final element in list) {
+      result = result * 31 + element.hashCode;
+    }
+    return result;
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,8 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
+  equatable: 2.0.5
 
 dev_dependencies:
+  lint: 2.2.0
   test: ^1.17.10
-  lints: ^1.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: pls
 description: pls is a lightweight library for parsing pls documents from document string.
-version: 1.0.4
+version: 1.1.0
 homepage: https://github.com/Andromo-App-Maker/pls
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  equatable: 2.0.5
+  equatable: ^2.0.5
 
 dev_dependencies:
-  lint: 2.2.0
+  lint: ^2.2.0
   test: ^1.17.10

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,9 +6,6 @@ homepage: https://github.com/Andromo-App-Maker/pls
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
-dependencies:
-  equatable: ^2.0.5
-
 dev_dependencies:
   lint: ^2.2.0
   test: ^1.17.10

--- a/test/pls_test.dart
+++ b/test/pls_test.dart
@@ -145,7 +145,7 @@ Version=2
 File1=http://relay5.181.fm:8068
 Length1=-1
 
-File2=https://muz9.z2.fm/8/e7/irina_allegrova_-_ugnala_tebja__ugnala_(zf.fm).mp3
+File2=https://mp3.barchin.com/1705323741_klavdia-petrivna-osty-chorn-bl.mp3
 Title2=MP3
 Length2=120
 

--- a/test/pls_test.dart
+++ b/test/pls_test.dart
@@ -23,7 +23,7 @@ void main() async {
     });
 
     test('Parses entry', () {
-      expect(plsParser.entries!.length, 2);
+      expect(plsParser.entries.length, 2);
     });
 
     test('Version not null', () {
@@ -41,7 +41,7 @@ void main() async {
     test('Parses version', () {
       expect(plsParser.version, 2);
     });
-    final PlsEntry entry = plsParser.entries![0];
+    final PlsEntry entry = plsParser.entries[0];
 
     test('Parses title', () {
       expect(
@@ -128,6 +128,56 @@ Version=2
             ),
             PlsEntry(
               file: "%UserProfile%\\Music\\short.ogg",
+              title: "example for an Environment variable",
+              length: 5,
+            ),
+          ],
+          version: 2,
+          numberOfEntries: 4,
+        ),
+      );
+    });
+
+    test('Playlist file empty or null', () {
+      const String fileString = """
+[playlist]
+
+File1=http://relay5.181.fm:8068
+Length1=-1
+
+File2=https://muz9.z2.fm/8/e7/irina_allegrova_-_ugnala_tebja__ugnala_(zf.fm).mp3
+Title2=MP3
+Length2=120
+
+File3=
+Title3=absolute path on Windows
+
+Title4=example for an Environment variable
+Length4=5
+
+NumberOfEntries=4
+Version=2
+    """;
+      final plsParser = PlsPlaylist.parse(fileString);
+      expect(
+        plsParser,
+        const PlsPlaylist(
+          entries: [
+            PlsEntry(
+              file: "http://relay5.181.fm:8068",
+              length: -1,
+            ),
+            PlsEntry(
+              file:
+                  "https://muz9.z2.fm/8/e7/irina_allegrova_-_ugnala_tebja__ugnala_(zf.fm).mp3",
+              title: "MP3",
+              length: 120,
+            ),
+            PlsEntry(
+              file: "",
+              title: "absolute path on Windows",
+            ),
+            PlsEntry(
               title: "example for an Environment variable",
               length: 5,
             ),

--- a/test/pls_test.dart
+++ b/test/pls_test.dart
@@ -4,7 +4,8 @@ import 'package:test/test.dart';
 
 void main() async {
   group('Parse pls file', () {
-    final String fileString = """[playlist]
+    const String fileString = """
+[playlist]
     numberofentries=2
     File1=http://example/stream/1
     Title1=EXAMPLE | FM
@@ -40,7 +41,6 @@ void main() async {
     test('Parses version', () {
       expect(plsParser.version, 2);
     });
-
     final PlsEntry entry = plsParser.entries![0];
 
     test('Parses title', () {
@@ -60,8 +60,82 @@ void main() async {
     });
 
     test('Parses length', () {
-      expect(entry.length, -1,
-          reason: "the parsed length doesn’t match the expected one");
+      expect(
+        entry.length,
+        -1,
+        reason: "the parsed length doesn’t match the expected one",
+      );
+    });
+
+    test('Playlist without title', () {
+      const String fileString = """
+[playlist]
+NumberOfEntries=1
+File1=http://live.viacom.id:8800/
+
+    """;
+      final plsParser = PlsPlaylist.parse(fileString);
+      expect(
+        plsParser,
+        const PlsPlaylist(
+          entries: [
+            PlsEntry(
+              file: "http://live.viacom.id:8800/",
+            ),
+          ],
+          numberOfEntries: 1,
+        ),
+      );
+    });
+
+    test('Playlist from https://en.wikipedia.org/wiki/PLS_(file_format)', () {
+      const String fileString = r"""
+[playlist]
+
+File1=http://relay5.181.fm:8068
+Length1=-1
+
+File2=example2.mp3
+Title2=Just some local audio that is 2mins long
+Length2=120
+
+File3=F:Music\whatever.m4a
+Title3=absolute path on Windows
+
+File4=%UserProfile%\Music\short.ogg
+Title4=example for an Environment variable
+Length4=5
+
+NumberOfEntries=4
+Version=2
+
+    """;
+      final plsParser = PlsPlaylist.parse(fileString);
+
+      expect(
+        plsParser,
+        const PlsPlaylist(
+          entries: [
+            PlsEntry(file: "http://relay5.181.fm:8068", length: -1),
+            PlsEntry(
+              file: "example2.mp3",
+              title: "Just some local audio that is 2mins long",
+              length: 120,
+            ),
+            PlsEntry(
+              file: "F:Music\\whatever.m4a",
+              title: "absolute path on Windows",
+            ),
+            PlsEntry(
+              file: "%UserProfile%\\Music\\short.ogg",
+              title: "example for an Environment variable",
+              length: 5,
+            ),
+          ],
+          version: 2,
+          numberOfEntries: 4,
+        ),
+      );
     });
   });
 }


### PR DESCRIPTION
- Properly handle optional titles and lengths according to PLS format.
- Override `==` and `hashCode` for `PlsEntry` and `PlsPlaylist`.
- Add linter.